### PR TITLE
Support multiple row insertion

### DIFF
--- a/src/main/resources/bigquery-tabledata/insertAllTableData.xml
+++ b/src/main/resources/bigquery-tabledata/insertAllTableData.xml
@@ -64,9 +64,7 @@
                 "skipInvalidRows": "$1",
                 "ignoreUnknownValues": "$2",
                 "templateSuffix": "$3",
-                "rows": [
-                $4
-                ]
+                "rows": $4
                 }
             </format>
             <args>


### PR DESCRIPTION
## Purpose
> Currently there is no support for inserting multiple data rows, in the BigQuery connector. Although, BigQuery supports multiple row insertions, the Json formatter in the connector is not supporting json arrays. This fix is to support json arrays in the formatter, so that multiple data rows can be constructed and sent.

Fixes: https://github.com/wso2-extensions/esb-connector-bigquery/issues/21