### PR TITLE
Fix unncessarily removing the double backslashes from the final JSON payload

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/BigQueryJsonFormatter.java
+++ b/src/main/java/org/wso2/carbon/connector/BigQueryJsonFormatter.java
@@ -65,7 +65,7 @@ public class BigQueryJsonFormatter extends AbstractConnector {
                     JSONObject rowdata = new JSONObject(jsonString);
                     finalDataArray.put(rowdata);
                 }
-                return finalDataArray.toString().replace("\\\\", "");
+                return finalDataArray.toString();
             } catch (Exception e) {
                 throw new SynapseException("Error while formatting the json", e);
             }

--- a/src/main/resources/bigquery-tabledata/insertAllTableData.xml
+++ b/src/main/resources/bigquery-tabledata/insertAllTableData.xml
@@ -39,24 +39,6 @@
         <property name="uri.var.jsonPay" expression="$func:jsonPay"/>
         <class name="org.wso2.carbon.connector.BigQueryJsonFormatter"/>
         <property name="uri.var.formattedJsonPayload" expression="get-property('uri.var.formattedJsonPay')"/>
-        <script language="js">
-            <![CDATA[
-            var payload = mc.getPayloadJSON();
-            var skipInvalidRows = mc.getProperty("uri.var.skipInvalidRows");
-            var ignoreUnknownValues = mc.getProperty("uri.var.ignoreUnknownValues");
-            var templateSuffix = mc.getProperty("uri.var.templateSuffix");
-            if(skipInvalidRows != null && skipInvalidRows != ""){
-                payload.skipInvalidRows = skipInvalidRows;
-            }
-            if(ignoreUnknownValues != null && ignoreUnknownValues != ""){
-                payload.ignoreUnknownValues = ignoreUnknownValues;
-            }
-            if(templateSuffix != null && templateSuffix != ""){
-                payload.templateSuffix = templateSuffix;
-            }
-            mc.setPayloadJSON(payload);
-            ]]>
-        </script>
         <payloadFactory media-type="json">
             <format>
                 {


### PR DESCRIPTION
## Purpose

This fix is done as a postfix to the improvement done at [1]. Since this PR [1] has removed unnecessary escaping of JSON payloads, we can assume that there might not be any unnecessary escape characters to be removed. Because doing so is leading to other issues as mentioned in [2].

Also, this PR removes redundant logic that was implemented using the script mediator.

[1] - https://github.com/wso2-extensions/esb-connector-bigquery/pull/35
[2] - https://github.com/wso2/micro-integrator/issues/3397

